### PR TITLE
built out timeseries get route

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,60 @@ your browser. You should see a "Hello World" message.
 ## Help
 
 If you have any questions, feel free to reach out to your interview scheduler for clarification!
+
+## Endpoint documentation
+
+hit the GET endpoint `localhost:3000/time-series` using the following parameters:
+
+- `partitionByYear`: required, boolean. true returns data parsed by year
+- `partitionByMonth`: required, boolean. true returns data parsed by month
+- `partitionByDate`: required, boolean. true returns data parsed by day
+- `partitionByDayOfWeek`: boolean. true returns data parsed by day of the week
+- `startDate`: optional. the first day to include in the calculations (inclusive). defaults to no filter
+- `endDate`: optional. the last day to include in the calculations (inclusive). defaults to no filter. returns no results if end date is before the start date.
+- `partitionByType`: required, string, options: user, role, group, or none. What the results will be partitioned on.
+- `calculation`: required, string, options: total, max, min, average, count. Can query for multiple stats at once using a comma separated list (ie 'total,average')
+- `userId`: optional, int. Id of user to query
+- `groupId`: optional, int. Id of group to query
+
+example query and result:
+
+`localhost:3000/time-series?partitionByType=group&startDate=2021-01-01&endDate=2021-01-31&partitionByYear=true&partitionByMonth=true&calculation=total, average, max, min&partitionByDay=false`
+
+```
+[
+    {
+        "sum": "4516888",
+        "avg": "25093.822222222222",
+        "max": 49728,
+        "min": 1813,
+        "year": "2021",
+        "month": "January",
+        "month_id": "1",
+        "group_id": 1,
+        "group_name": "Northeast Sales Team"
+    },
+    {
+        "sum": "4783425",
+        "avg": "26138.934426229508",
+        "max": 49904,
+        "min": 1387,
+        "year": "2021",
+        "month": "January",
+        "month_id": "1",
+        "group_id": 2,
+        "group_name": "West Coast Sales Team"
+    },
+    {
+        "sum": "3277567",
+        "avg": "28750.587719298246",
+        "max": 49904,
+        "min": 1505,
+        "year": "2021",
+        "month": "January",
+        "month_id": "1",
+        "group_id": 3,
+        "group_name": "Digital Sales Team"
+    }
+]
+```

--- a/db.js
+++ b/db.js
@@ -1,0 +1,11 @@
+const config = {
+    host: 'db',
+    port: '5432',
+    user: 'user',
+    password: 'pass',
+    database: 'actifai'
+};
+
+module.exports = {
+    config
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "4.16.1",
-        "pg": "8.7.1"
+        "pg": "8.7.1",
+        "validatorjs": "^3.22.1"
       }
     },
     "node_modules/accepts": {
@@ -616,6 +617,11 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/validatorjs": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/validatorjs/-/validatorjs-3.22.1.tgz",
+      "integrity": "sha512-451KiCt/3E8qV/8fOUdO0YkA8zUdQBNVxubg9jvgEB+JAg9IlRKrClzwq2ir2ndj7TWmPYQ7bXFb4BxcyX2iWw=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1093,6 +1099,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "validatorjs": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/validatorjs/-/validatorjs-3.22.1.tgz",
+      "integrity": "sha512-451KiCt/3E8qV/8fOUdO0YkA8zUdQBNVxubg9jvgEB+JAg9IlRKrClzwq2ir2ndj7TWmPYQ7bXFb4BxcyX2iWw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "express": "4.16.1",
-    "pg": "8.7.1"
+    "pg": "8.7.1",
+    "validatorjs": "^3.22.1"
   }
 }

--- a/seed.js
+++ b/seed.js
@@ -2,18 +2,13 @@
 
 const { Client } = require('pg');
 const fs = require("fs");
+const db = require('./db');
 const groupsSqlInsert = fs.readFileSync("seedGroups.sql").toString();
 const userGroupsSqlInsert = fs.readFileSync("seedUserGroups.sql").toString();
 const usersSqlInsert = fs.readFileSync("seedUsers.sql").toString();
 const salesSqlInsert = fs.readFileSync("seedSales.sql").toString();
 
-const pgclient = new Client({
-  host: 'db',
-  port: '5432',
-  user: 'user',
-  password: 'pass',
-  database: 'actifai'
-});
+const pgclient = new Client(db.config);
 
 pgclient.connect();
 

--- a/server.js
+++ b/server.js
@@ -2,10 +2,15 @@
 
 const express = require('express');
 const seeder = require('./seed');
+const { Pool } = require('pg');
+const queryUtils = require('./timeseries-utils');
+const db = require('./db');
 
 // Constants
 const PORT = 3000;
 const HOST = '0.0.0.0';
+
+const pool = new Pool(db.config);
 
 async function start() {
   // Seed the database
@@ -19,10 +24,22 @@ async function start() {
     res.send('Hello World');
   });
 
-  // Write your endpoints here
+  app.get('/time-series', async (req, res) => {
+    try {
+      const { query, values } = queryUtils.formatQuery(req.query);
+      const result = await pool.query(query, values)
+      res.send(result.rows);
+    } catch (error) {
+      errorHandler(error, res)
+    }
+  })
 
   app.listen(PORT, HOST);
   console.log(`Server is running on http://${HOST}:${PORT}`);
+}
+
+function errorHandler (err, res) {
+  return res.status(400).send({message: err.message});
 }
 
 start();

--- a/timeseries-utils.js
+++ b/timeseries-utils.js
@@ -1,0 +1,193 @@
+const salesByGroup = `
+FROM user_groups
+LEFT JOIN users ON user_groups.user_id = users.id
+LEFT JOIN sales ON sales.user_id = users.id
+LEFT JOIN groups ON user_groups.group_id = groups.id
+`;
+const salesByUser = `
+FROM sales
+LEFT JOIN users ON sales.user_id = users.id
+`;
+
+const selectYear = `EXTRACT(year FROM date) AS year`;
+const selectMonth = `CASE
+    WHEN EXTRACT(month FROM date) = 1 THEN 'January'
+    WHEN EXTRACT(month FROM date) = 2 THEN 'February'
+    WHEN EXTRACT(month FROM date) = 3 THEN 'March'
+    WHEN EXTRACT(month FROM date) = 4 THEN 'April'
+    WHEN EXTRACT(month FROM date) = 5 THEN 'May'
+    WHEN EXTRACT(month FROM date) = 6 THEN 'June'
+    WHEN EXTRACT(month FROM date) = 7 THEN 'July'
+    WHEN EXTRACT(month FROM date) = 8 THEN 'August'
+    WHEN EXTRACT(month FROM date) = 9 THEN 'September'
+    WHEN EXTRACT(month FROM date) = 10 THEN 'October'
+    WHEN EXTRACT(month FROM date) = 11 THEN 'November'
+    WHEN EXTRACT(month FROM date) = 12 THEN 'December'
+END AS month, EXTRACT(month FROM date) as month_id`;
+const selectDOW = `CASE 
+    WHEN EXTRACT(DOW FROM date) = 0 THEN 'Sunday'
+    WHEN EXTRACT(DOW FROM date) = 1 THEN 'Monday'
+    WHEN EXTRACT(DOW FROM date) = 2 THEN 'Tuesday'
+    WHEN EXTRACT(DOW FROM date) = 3 THEN 'Wednesday'
+    WHEN EXTRACT(DOW FROM date) = 4 THEN 'Thursday'
+    WHEN EXTRACT(DOW FROM date) = 5 THEN 'Friday'
+    WHEN EXTRACT(DOW FROM date) = 6 THEN 'Saturday'
+END AS day_of_week, EXTRACT(DOW FROM date) as dow_id`;
+
+const validationRules = {
+    partitionByDay: 'required|boolean',
+    partitionByMonth: 'required|boolean',
+    partitionByYear: 'required|boolean',
+    partitionByDayOfWeek: 'boolean',
+    partitionByType: 'required|string|in:user,group,role,none',
+    groupId: 'integer',
+    userId: 'integer',
+    startDate: 'date',
+    endDate: 'date',
+    calculation: 'required|string'
+}
+
+const validator = require('validatorjs');
+
+const formatQuery = function(params) {
+
+    const validation = new validator(params, validationRules);
+    if (!validation.passes()) throw new Error('Invalid parameters passed into request.')
+
+    const { whereText, values, joinOnGroups } = formatWheres(params);
+
+    const { selections, groupBys, joinText } = formatPartitions(params, joinOnGroups);
+
+    const stat = getStat(params);
+
+    return {
+        query: `SELECT ${stat}, ${selections} ${joinText}
+        ${whereText}
+        GROUP BY ${groupBys}
+        ORDER BY ${groupBys}
+        `,
+        values
+    }
+}
+
+/**
+ * 
+ * @param {*} params of req
+ * @param joinOnGroups boolean - do we need to join group table no matter what the partitions are
+ * @returns table join sql and select sql
+ */
+const formatPartitions = function(params, joinOnGroups) {
+    const selections = [];
+    const groupBys = [];
+    let joinText;
+    const partitionParams = [
+        { name: 'partitionByYear', select: selectYear, groupBy: 'year' },
+        { name: 'partitionByMonth', select: selectMonth, groupBy: `month_id, month` },
+        { name: 'partitionByDayOfWeek', select: selectDOW, groupBy: `dow_id, day_of_week` },
+        { name: 'partitionByDay', select: 'date', groupBy: 'date'}
+    ]
+    partitionParams.forEach((partition) => {
+        const paramVal = params[partition.name];
+        if (paramVal === 'true') {
+            selections.push(partition.select);
+            groupBys.push(partition.groupBy);
+        }
+    })
+    // if all date partitions were set to false then its not a timeseries
+    if (!selections.length) {
+        throw new Error('Must have a time partition selected')
+    }
+    // if keys changed, update validator
+    const types = {
+        'user': {
+            select: `users.id as user_id, users.name as user_name`,
+            groupBy: `users.id, users.name`,
+            join: salesByUser
+        },
+        'group': {
+            select: `groups.id as group_id, groups.name as group_name`,
+            groupBy: `groups.id, groups.name`,
+            join: salesByGroup
+        },
+        'role': {
+            select: `role`,
+            groupBy: `role`,
+            join: salesByUser
+        }
+    }
+    if (params.partitionByType === 'none') {
+        joinText = salesByUser;
+    } else {
+        selections.push(types[params.partitionByType].select);
+        groupBys.push(types[params.partitionByType].groupBy);
+        joinText = types[params.partitionByType].join;
+    }
+    // override if querying on a single group_id, we must join the group table
+    if (joinOnGroups && params.partitionByType !== 'group') joinText = salesByGroup;
+    return { selections: selections.join(', '), groupBys: groupBys.join(', '), joinText };
+}
+
+/**
+ * 
+ * @param {*} params of req
+ * @returns where sql text and corresponding values
+ */
+const formatWheres = function(params) {
+    let whereText = '';
+    let counter = 1;
+    const values = [];
+    let joinOnGroups = false;
+    const filterParams = [
+        {
+            name: 'startDate',
+            text: 'date >= $counter::date',
+            method: formatDate
+        },
+        {
+            name: 'endDate',
+            text: 'date <= $counter::date',
+            method: formatDate
+        },
+        {
+            name: 'userId',
+            text: 'users.id=$counter::int',
+        },
+        {
+            name: 'groupId',
+            text: 'group_id=$counter::int'
+        }
+    ]
+    filterParams.forEach((filter) => {
+        const paramVal = params[filter.name];
+        if (paramVal) {
+            whereText += `${whereText ? 'AND ': ''}${filter.text.replace('counter', counter.toString())}\n`;
+            const val = filter.method ? filter.method(paramVal) : paramVal;
+            values.push(val)
+            counter++;
+            if (filter.name === 'groupId') joinOnGroups = true;
+        }
+    });
+    return { whereText: whereText ? `WHERE ${whereText}` : '', values, joinOnGroups };
+}
+
+const getStat = function(params) {
+    const paramStats = params.calculation.split(',');
+    const funcs = {
+        'average': 'AVG',
+        'count': 'COUNT',
+        'total': 'SUM',
+        'min': 'MIN',
+        'max': 'MAX',
+    }
+    const stats = paramStats.map(stat => funcs[stat.trim()] ? (funcs[stat.trim()] + '(amount)') : null).filter(Boolean);
+    return stats.join(', ');
+}
+
+const formatDate = function(date) {
+    const d = new Date(date);
+    return d.toISOString().split('T')[0]; // 'YYYY-MM-DD'
+}
+
+module.exports = {
+    formatQuery
+}


### PR DESCRIPTION
Added endpoint to retrieve time-series data, partitioned by day, day of week, month, or year that the UI can use to create dashboards.

GET localhost:3000/time-series

with params:
- partitionByYear
- partitionByMonth
- partitionByDate
- partitionByDayOfWeek (optional)
- startDate (optional)
- endDate (optional)
- partitionByType
- userId (optional)
- groupId (optional)

ex response:
```
[
    {
        "sum": "4516888",
        "avg": "25093.822222222222",
        "max": 49728,
        "min": 1813,
        "year": "2021",
        "month": "January",
        "month_id": "1",
        "group_id": 1,
        "group_name": "Northeast Sales Team"
    }
]
```